### PR TITLE
patches user_model to allow for retrieving the avatar

### DIFF
--- a/lib/open_project/local_avatars/engine.rb
+++ b/lib/open_project/local_avatars/engine.rb
@@ -36,7 +36,12 @@ module OpenProject::LocalAvatars
       require_dependency 'project'
     end
 
-    patches [:User, :AvatarHelper, :MyController, :UsersController, :UsersHelper]
+    patches [:User,
+             :AvatarHelper,
+             :MyController,
+             :UsersController,
+             :UsersHelper,
+             :'API::V3::Users::UserModel']
   end
 end
 

--- a/lib/open_project/local_avatars/patches/api/v3/users/user_model_patch.rb
+++ b/lib/open_project/local_avatars/patches/api/v3/users/user_model_patch.rb
@@ -1,0 +1,19 @@
+module OpenProject::LocalAvatars
+  module Patches
+    module API
+      module V3
+        module Users
+          module UserModelPatch
+            def self.included(base) # :nodoc:
+              base.class_eval do
+                def local_avatar_attachment
+                  model.local_avatar_attachment
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/helpers/avatar_helper_spec.rb
+++ b/spec/helpers/avatar_helper_spec.rb
@@ -1,0 +1,81 @@
+require 'spec_helper'
+
+describe AvatarHelper, :type => :helper do
+  let(:user) { FactoryGirl.build_stubbed(:user) }
+  let(:avatar_stub) { FactoryGirl.build_stubbed(:avatar_attachment) }
+
+  before do
+    allow(user).to receive(:local_avatar_attachment).and_return avatar_stub
+  end
+
+  def expected_image_tag(user)
+    tag_options = { title: user.name,
+                    alt: 'Avatar',
+                    class: 'avatar' }
+
+    image_tag expected_url(user), tag_options
+  end
+
+  def expected_url(user)
+    users_dump_avatar_url(user)
+  end
+
+  def expected_gravatar_url(user)
+    digest = Digest::MD5.hexdigest(user.mail)
+    host = "http://gravatar.com"
+
+    "#{host}/avatar/#{digest}?secure=false"
+  end
+
+  def expected_gravatar_image_tag(user)
+    tag_options = { title: user.name,
+                    alt: 'Gravatar',
+                    class: 'avatar' }
+
+    image_tag expected_gravatar_url(user), tag_options
+  end
+
+  describe :avatar do
+    it "should return the image attached to the user" do
+      with_settings gravatar_enabled: '1' do
+        expect(helper.avatar(user)).to eq(expected_image_tag(user))
+      end
+    end
+
+    it "should return the gravatar image if no image uploaded for the user" do
+      allow(user).to receive(:local_avatar_attachment).and_return nil
+
+      with_settings gravatar_enabled: '1' do
+        expect(helper.avatar(user)).to eq(expected_gravatar_image_tag(user))
+      end
+    end
+
+    it "should return blank if image attached to the user but gravatars disabled" do
+      with_settings gravatar_enabled: '0' do
+        expect(helper.avatar(user)).to be_blank
+      end
+    end
+  end
+
+  describe :avatar_url do
+    it "should return the url to the image attached to the user" do
+      with_settings gravatar_enabled: '1' do
+        expect(helper.avatar_url(user)).to eq(expected_url(user))
+      end
+    end
+
+    it "should return the gravatar url if no image uploaded for the user" do
+      allow(user).to receive(:local_avatar_attachment).and_return nil
+
+      with_settings gravatar_enabled: '1' do
+        expect(helper.avatar_url(user)).to eq(expected_gravatar_url(user))
+      end
+    end
+
+    it "should return blank if image attached to the user but gravatars disabled" do
+      with_settings gravatar_enabled: '0' do
+        expect(helper.avatar_url(user)).to be_blank
+      end
+    end
+  end
+end


### PR DESCRIPTION
I use the standard way of patching the API user model here. We might need to provide a specific way of patching API models or drop models altogether. As this is not decided, I used the simple way.

:exclamation: requires https://github.com/opf/openproject/pull/1725 to be merged :exclamation: 

https://www.openproject.org/work_packages/13706
