### PR TITLE
[22099] Apply new icon styling (Local Avatars)

### DIFF
--- a/app/views/users/_avatar.html.erb
+++ b/app/views/users/_avatar.html.erb
@@ -19,7 +19,7 @@
         </div>
       </div>
       <p>
-        <%= styled_button_tag l(:button_save), class: '-highlight -with-icon icon-yes' %>
+        <%= styled_button_tag l(:button_save), class: '-highlight -with-icon icon-checkmark' %>
         <% if @user.local_avatar_attachment %>
             <%= submit_tag l(:button_delete), name: 'delete',
                            confirm: l(:are_you_sure_delete_avatar),


### PR DESCRIPTION
This applies the new icon styling in the plugin. Note that this only works in combination with https://github.com/opf/openproject/pull/3873 since there the icon font is updated.

https://community.openproject.org/projects/local-avatars/work_packages/details/22099/overview
