### PR TITLE
Fix RMagick deprecation warning

### DIFF
--- a/lib/open_project/local_avatars/patches/user_patch.rb
+++ b/lib/open_project/local_avatars/patches/user_patch.rb
@@ -16,7 +16,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-require 'RMagick'
+require 'rmagick'
 
 module OpenProject::LocalAvatars
   module Patches


### PR DESCRIPTION
This removes the deprecation warning
`<..>/RMagick.rb:4:in`<top (required)>' : [DEPRECATION] requiring "RMagick" is deprecated. Use "rmagick" instead (StandardWarning)`
