### PR TITLE
Revert imagemagick dependency to 2.12.2

### DIFF
--- a/lib/open_project/local_avatars/patches/user_patch.rb
+++ b/lib/open_project/local_avatars/patches/user_patch.rb
@@ -16,7 +16,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-require 'rmagick'
+require 'RMagick'
 
 module OpenProject::LocalAvatars
   module Patches

--- a/openproject-local_avatars.gemspec
+++ b/openproject-local_avatars.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |s|
   s.test_files = Dir["spec/**/*"]
 
   s.add_dependency 'rails', '~> 4.2.4'
-  s.add_dependency 'rmagick', '~> 2.15.4'
+  s.add_dependency 'rmagick', '~> 2.12.2'
 
 end


### PR DESCRIPTION
SLES 11.3 only ships with `ImageMagick Version: 6.4.3.6-7.30.1`,
which is incompatible with newer rmagick versions.

/cc @crohr 
