### PR TITLE
[20524] [Accessibility] Some pages do not have their own window title (Local Avatars)

### DIFF
--- a/app/views/my/avatar.html.erb
+++ b/app/views/my/avatar.html.erb
@@ -1,3 +1,4 @@
 <% breadcrumb_paths(l(:label_my_account), l(:button_change_avatar)) %>
 <%= toolbar title: l(:button_change_avatar) %>
+<% html_title l(:label_my_account), l(:button_change_avatar) %>
 <%= render :partial => 'users/avatar' %>


### PR DESCRIPTION
This inserts concrete html title attributes for some pages. Thus it is easier for blind users to navigate through the application.

https://community.openproject.com/work_packages/20524/activity
